### PR TITLE
fix: SHA-pin all 3rd-party GitHub Actions (supply chain hardening)

### DIFF
--- a/.github/workflows/ci-firefly-private-connector-helm.yaml
+++ b/.github/workflows/ci-firefly-private-connector-helm.yaml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   call-release-helm-workflow:
-    uses: infralight/.github/.github/workflows/git-release-helm.yaml@master
+    uses: infralight/.github/.github/workflows/git-release-helm.yaml@5a6cb3462fa8ca2fb0a7564a03f5f6c475fa6306 # master
     with:
       branch: ${{ github.ref_name }}

--- a/.github/workflows/ci-firefly-private-connector.yaml
+++ b/.github/workflows/ci-firefly-private-connector.yaml
@@ -25,7 +25,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Get current time
-      uses: gerred/actions/current-time@master
+      uses: gerred/actions/current-time@c3950138908da5fe2b904f1dc39535d565f1547f # master
       id: current-time
 
     - name: Build and push image to prod


### PR DESCRIPTION
## Summary
Pin all 3rd-party action references to immutable SHA digests.

## Why
Mutable tags can be force-pushed by attackers to point at malicious commits (as happened with aquasecurity/trivy-action on 2026-03-19). SHA-pinned references are immutable and safe from this class of attack.

No functional changes -- all SHAs resolve to the same versions previously referenced by tag.